### PR TITLE
Fixed configuration load

### DIFF
--- a/src/Slack.js
+++ b/src/Slack.js
@@ -35,7 +35,7 @@ class Slack {
         {
           color: color,
           title: `${notification.message} ${icon} ${icon} ${icon}`,
-          text: `Invocation ID: ${notification.invocationId}\nStage: ${notification.stage}\nRegion: ${notification.region}\nDeployer:${notification.deployer}
+          text: `Invocation ID: ${notification.invocationId}\nStage: ${notification.stage}\nRegion: ${notification.region}\nDeployer: ${notification.deployer}
           `,
           author_name: 'Serverless Plugin Notification',
           author_link: 'https://github.com/maasglobal/serverless-plugin-notification',


### PR DESCRIPTION
Configuration from serverless.yml are not properly parsed in plugin constructor, here some infos and the fix applied:
https://forum.serverless.com/t/serverless-plugin-resolving-variable-references/2233

It fix also a missing space in Deployer name